### PR TITLE
Update spec to use `indexOf` instead of `includes` for cross platform  support

### DIFF
--- a/spec/mad_lib_spec.js
+++ b/spec/mad_lib_spec.js
@@ -13,7 +13,7 @@ describe("MadLib", function() {
     replaceVerbs();
 
     expectedVerb = $(".verb").first().text();
-    expect(verbs.includes(expectedVerb)).toBe(true)
+    expect(verbs.indexOf(expectedVerb)).not.toEqual(-1);
 
   });
 
@@ -27,7 +27,7 @@ describe("MadLib", function() {
 
     replaceNouns();
     expectedNoun = $(".noun").first().text();
-    expect(nouns.includes(expectedNoun)).toBe(true)
+    expect(nouns.indexOf(expectedNoun)).not.toEqual(-1);
   });
 
 });


### PR DESCRIPTION
Fixes issue #9 #7 and has spec run same expectation using `indexOf` 
